### PR TITLE
Version 2.2, consolidate default settings, change middle-mouse default

### DIFF
--- a/viewImageContextMenuItem/background.js
+++ b/viewImageContextMenuItem/background.js
@@ -1,3 +1,14 @@
+window.DEFAULT_OPTIONS = Object.freeze({
+    "show-view-image": true,
+    "show-view-video": true,
+    "override-referer": true,
+    "left-click-action": "same-tab",
+    "ctrl-left-click-action": "new-foreground-tab",
+    "shift-left-click-action": "new-foreground-window",
+    "ctrl-shift-left-click-action": "new-background-tab",
+    "middle-click-action": "new-background-tab"
+  });
+
 function createMenuItems() {
   browser.menus.create({
     id: "view-image-context-menu-item",
@@ -97,18 +108,6 @@ function handleContextMenuItemClick(info, tab) {
   doAction(info, tab, actionType);
 }
 
-function generateDefaultOptions() {
-  return {
-    "show-view-image": true,
-    "show-view-video": true,
-    "override-referer": true,
-    "left-click-action": "same-tab",
-    "ctrl-left-click-action": "new-foreground-tab",
-    "shift-left-click-action": "new-foreground-window",
-    "ctrl-shift-left-click-action": "new-background-tab",
-    "middle-click-action": "new-foreground-tab"
-  };
-}
 
 function loadOptionsFromStorage() {
   browser.storage.local.get("options")
@@ -139,7 +138,7 @@ function processOptions(options) {
 }
 
 createMenuItems();
-processOptions(generateDefaultOptions());
+processOptions(window.DEFAULT_OPTIONS);
 loadOptionsFromStorage();
 browser.menus.onClicked.addListener(handleContextMenuItemClick);
 browser.storage.onChanged.addListener(handleStorageChange);

--- a/viewImageContextMenuItem/manifest.json
+++ b/viewImageContextMenuItem/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "View Image Context Menu Item",
-  "version": "2.1.1",
+  "version": "2.2",
   "description": "Adds View Image and View Video to the context menu",
   "icons": {
     "48": "icons/viewImageContextMenuItem-48.png"

--- a/viewImageContextMenuItem/options.js
+++ b/viewImageContextMenuItem/options.js
@@ -1,14 +1,5 @@
-function generateDefaultOptions() {
-  return {
-    "show-view-image": true,
-    "show-view-video": true,
-    "override-referer": true,
-    "left-click-action": "same-tab",
-    "ctrl-left-click-action": "new-foreground-tab",
-    "shift-left-click-action": "new-foreground-window",
-    "ctrl-shift-left-click-action": "new-background-tab",
-    "middle-click-action": "new-foreground-tab"
-  };
+function getDefaultOptions() {
+  return browser.extension.getBackgroundPage().DEFAULT_OPTIONS;
 }
 
 function loadOptions() {
@@ -17,7 +8,7 @@ function loadOptions() {
   }
 
   browser.storage.local.get("options").then((res) => {
-    const options = res.options || generateDefaultOptions();
+    const options = res.options || getDefaultOptions();
     document.querySelector("#show-view-image").checked = options["show-view-image"];
     document.querySelector("#show-view-video").checked = options["show-view-video"];
     document.querySelector("#override-referer").checked = options["override-referer"];


### PR DESCRIPTION
this pr changes two things:
- change `middle-click-action` to be `new-background-tab` instead of `new-foreground-tab`. this will affect anyone who has not explicitly saved their options.
- make default options a constant object in the background script that the options script accesses instead of defining defaults in both scripts