### PR TITLE
Version 2.4; hide menu items when nagivated; make options fallback to default

### DIFF
--- a/viewImageContextMenuItem/manifest.json
+++ b/viewImageContextMenuItem/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "View Image Context Menu Item",
-  "version": "2.3.1",
+  "version": "2.4",
   "description": "Adds View Image and View Video to the context menu",
   "icons": {
     "48": "icons/viewImageContextMenuItem-48.png"

--- a/viewImageContextMenuItem/options.html
+++ b/viewImageContextMenuItem/options.html
@@ -6,7 +6,7 @@
     div.section-option { margin-bottom: 1em; }
     div.section-submission { margin-top: 1em; }
     label.block-label { display: block; margin-bottom: 0.2em; }
-    label {font-weight: bold; }
+    label { font-weight: bold; }
   </style>
 </head>
 <body>

--- a/viewImageContextMenuItem/options.js
+++ b/viewImageContextMenuItem/options.js
@@ -1,14 +1,9 @@
-function getDefaultOptions() {
-  return browser.extension.getBackgroundPage().DEFAULT_OPTIONS;
-}
-
 function loadOptions() {
   function setSelectedOption(selectId, value){
     document.querySelector(selectId + " > option[value='" + value + "']").selected = true;
   }
 
-  browser.storage.local.get("options").then((res) => {
-    const options = res.options || getDefaultOptions();
+  browser.extension.getBackgroundPage().loadOptionsFromStorage().then((options) => {
     document.querySelector("#show-view-image").checked = options["show-view-image"];
     document.querySelector("#show-view-video").checked = options["show-view-video"];
     document.querySelector("#override-referer").checked = options["override-referer"];


### PR DESCRIPTION
Change how options are handled - move loading code to the background script completely as well as falling back to the default options if there are missing keys in the storage options (will be useful if new keys are ever added)

Change how options are applied; instead of hiding/showing menu items when options are updated, instead hide/show menu item every time the menu is opened - this allows the menu items to be hidden if the add-on detects that the page url and the image url are the same (ie. the image is already opened)