### PR TITLE
Version 3.2.1 - fix options page not properly loading options in incognito

### DIFF
--- a/viewImageContextMenuItem/background.js
+++ b/viewImageContextMenuItem/background.js
@@ -255,9 +255,16 @@ function processOptions(options) {
   window.options = options;
 }
 
+function loadOptionsFromStorageMessageListener(request, sender, sendResponse) {
+  if(request && request.getOptions === true) {
+    sendResponse(loadOptionsFromStorage());
+  }
+}
+
 createMenuItems();
 processOptions(window.DEFAULT_OPTIONS);
 loadOptionsFromStorage().then((options) => { processOptions(options); });
 browser.menus.onShown.addListener(handleContextMenuShow);
 browser.menus.onClicked.addListener(handleContextMenuItemClick);
 browser.storage.onChanged.addListener(handleStorageChange);
+browser.runtime.onMessage.addListener(loadOptionsFromStorageMessageListener);

--- a/viewImageContextMenuItem/manifest.json
+++ b/viewImageContextMenuItem/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "View Image Context Menu Item",
-  "version": "3.2",
+  "version": "3.2.1",
   "description": "Adds View Audio, View Image, and View Video to the context menu",
   "default_locale": "en-CA",
   "icons": {

--- a/viewImageContextMenuItem/options.js
+++ b/viewImageContextMenuItem/options.js
@@ -3,7 +3,7 @@ function loadOptions() {
     document.querySelector(selectId + " > option[value='" + value + "']").selected = true;
   }
 
-  browser.extension.getBackgroundPage().loadOptionsFromStorage().then((options) => {
+  browser.runtime.sendMessage({ getOptions: true }).then((options) => {
     document.querySelector("#show-view-audio").checked = options["show-view-audio"];
     document.querySelector("#show-view-image").checked = options["show-view-image"];
     document.querySelector("#show-view-video").checked = options["show-view-video"];


### PR DESCRIPTION
the options.js script needs access the background.js script to have a singular way for all scripts to access default options.
this was done by `browser.extension.getBackgroundPage()` - but that does not work if the `about:addons` page is opened in incognito. this pr should fix that by instead using messaging.