### PR TITLE
Version 3.3 - add Accept header override

### DIFF
--- a/viewImageContextMenuItem/manifest.json
+++ b/viewImageContextMenuItem/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "View Image Context Menu Item",
-  "version": "3.2.1",
+  "version": "3.3",
   "description": "Adds View Audio, View Image, and View Video to the context menu",
   "default_locale": "en-CA",
   "icons": {

--- a/viewImageContextMenuItem/options.html
+++ b/viewImageContextMenuItem/options.html
@@ -29,6 +29,10 @@
     <label for="override-referer">Override Referer header in requests</label>
   </div>
   <div class="browser-style section-option">
+    <input type="checkbox" id="override-accept" checked="checked" />
+    <label for="override-accept">Override Accept header in requests</label>
+  </div>
+  <div class="browser-style section-option">
     <label class="block-label">Left-Click</label>
     <select class="browser-style" id="left-click-action">
       <option value="same-tab">Open in same tab</option>

--- a/viewImageContextMenuItem/options.js
+++ b/viewImageContextMenuItem/options.js
@@ -8,6 +8,7 @@ function loadOptions() {
     document.querySelector("#show-view-image").checked = options["show-view-image"];
     document.querySelector("#show-view-video").checked = options["show-view-video"];
     document.querySelector("#override-referer").checked = options["override-referer"];
+    document.querySelector("#override-accept").checked = options["override-accept"];
     setSelectedOption("#middle-click-action", options["middle-click-action"]);
     setSelectedOption("#ctrl-left-click-action", options["ctrl-left-click-action"]);
     setSelectedOption("#shift-left-click-action", options["shift-left-click-action"]);
@@ -30,6 +31,7 @@ function saveOptions(event) {
     "show-view-image": document.querySelector("#show-view-image").checked,
     "show-view-video": document.querySelector("#show-view-video").checked,
     "override-referer": document.querySelector("#override-referer").checked,
+    "override-accept": document.querySelector("#override-accept").checked,
     "left-click-action": document.querySelector("#left-click-action").value,
     "ctrl-left-click-action": document.querySelector("#ctrl-left-click-action").value,
     "shift-left-click-action": document.querySelector("#shift-left-click-action").value,


### PR DESCRIPTION
Add logic to override the `Accept` header with what Firefox usually uses for various media.
This appears to affect certain sites, like reddit.

Without overriding the Accept header, the default first MIME type is `text/html` which causes some requests to serve HTML pages instead of the image itself; with the Accept header override, the MIME type does not start with `text/html` so the HTML page is not served. This will of course depend on how servers handle the Accept header.